### PR TITLE
update terraform-provider-sakuracloud v0.11.0

### DIFF
--- a/terraform-provider-sakuracloud/terraform-provider-sakuracloud.nuspec
+++ b/terraform-provider-sakuracloud/terraform-provider-sakuracloud.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <!-- == PACKAGE SPECIFIC SECTION == -->
     <id>terraform-provider-sakuracloud</id>
-    <version>0.10.4</version>
+    <version>0.11.0</version>
     <owners>223n (@223n)</owners>
     <!-- ============================== -->
 
@@ -36,17 +36,37 @@
     <releaseNotes>
 # EN
 ## ChangeLog
-  - Add textlint rule #153
-  - Support Linuxbrew #155
-  - Add throttling to cloud API call #157
+  - Fixed packet filter setting example of document #159
+  - Support Object storage #161
+  - Fixed resource regeneration judgment at packet filter update #162
+  - Celan up the sample .tf file #163
+  - Support "go get" #164
+  - Format of tf file using "terraform fmt" command #165
+  - Add icon (sakuracloud_icon) #167
+  - Add Server connector resource #168
+  - Code improvements #169
+
+## Remarks
+  - For details, please check CHANGELOG (Japanese) of GitHub.
+  - https://github.com/sacloud/usacloud/releases/tag/v0.0.13
 
 ----
 
 # JP
 ## ChangeLog
-  - textlintルール追加 #153
-  - Linuxbrew対応 #155
-  - クラウドAPI呼び出しへのスロットリング追加 #157
+  - ドキュメントのパケットフィルタ設定例を修正 #159
+  - オブジェクトストレージ対応 #161
+  - パケットフィルタ更新時のリソース再生成判定を修正 #162
+  - サンプル.tfファイルのクリーンアップ #163
+  - go get対応 #164
+  - tfファイルのフォーマット #165
+  - アイコン(sakuracloud_icon)追加 #167
+  - サーバ コネクタリソース追加 #168
+  - コード改善 #169
+
+## Remarks
+  - 詳しくは、GitHubのCHANGELOG(日本語)をご確認ください。
+  - https://github.com/sacloud/terraform-provider-sakuracloud/releases/tag/v0.11.0
     </releaseNotes>
     <!-- =============================== -->      
   </metadata>

--- a/terraform-provider-sakuracloud/tools/chocolateyinstall.ps1
+++ b/terraform-provider-sakuracloud/tools/chocolateyinstall.ps1
@@ -3,11 +3,11 @@
 $packageName  = $env:ChocolateyPackageName;
 $toolsDir     = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)";
 $softwareName = 'terraform-provider-sakuracloud*';
-$url          = 'https://github.com/sacloud/terraform-provider-sakuracloud/releases/download/v0.10.4/terraform-provider-sakuracloud_windows-386.zip';
-$url64        = 'https://github.com/sacloud/terraform-provider-sakuracloud/releases/download/v0.10.4/terraform-provider-sakuracloud_windows-amd64.zip';
+$url          = 'https://github.com/sacloud/terraform-provider-sakuracloud/releases/download/v0.11.0/terraform-provider-sakuracloud_windows-386.zip';
+$url64        = 'https://github.com/sacloud/terraform-provider-sakuracloud/releases/download/v0.11.0/terraform-provider-sakuracloud_windows-amd64.zip';
 $checkSum     = 'sha512';
-$hash32       = '949F30F2204999D3F79627B51D163ED0D60663CA9ADDE6F497D761C2F06E16F2A865C7A9AA81F9932D089D9E598B20C5F44B81F0FB7BCE9F1A778ADEAAECA66C';
-$hash64       = 'B158D4B5771FB84EB3346F99FDBEB53739E3A3009909C9606BD04EB5EFBAB0B1040791AD1DEA7F27913ED14BE4BC3107E9EAC9B7C2E8BD248E19EC944C227D13';
+$hash32       = '0903E3AEA47B8B276709084D989B4E39604DEB5019CDD721D39D38F05ED07DFDAE64103084EF3BFBD5502EB777FD8F6799DB3BE008D943BFF3ECF9EBF9350030';
+$hash64       = 'E939CBD8D99078161F65EB02D9EAF7D6B4197A3A9BB7DC7660A68FA29A82C537B535B18386B94F7B3117BE9797D4ED036B79D872514B01D31F633F50E9B47D6D';
 
 $packageArgs = @{
   packageName   = $packageName


### PR DESCRIPTION
update terraform-provider-sakuracloud ver.0.11.0

chocolateyで配信されたらmergeします。
https://chocolatey.org/packages/terraform-provider-sakuracloud/0.11.0
